### PR TITLE
Update printer_octopus.cfg

### DIFF
--- a/printer_octopus.cfg
+++ b/printer_octopus.cfg
@@ -2,21 +2,17 @@
 
 [include generic-bigtreetech-xxxx.cfg]
 
+[include timelapse.cfg]
 
 # See docs/Config_Reference.md for a description of parameters.
-#MACROS AT THE BOTTOM OF THE CONFIG
- 
- #Exhaust Fan, Top left inside of panel, Pins: J56
- #Main Board Cooling Fan Pins: J57
- #Extruder Fan/Fan 0 Pins: J50
- #Parts cooling fan Pins: 
+
+#MACROS AT THE BOTTOM OF THE CONFIG 
 
 [virtual_sdcard]
 path: ~/printer_data/gcodes
 #/home/pi/printer_data/gcodes
 
 [display_status]
-
   
 # Motor 0 on schematic
 [stepper_x]
@@ -241,21 +237,18 @@ z_hop: 10                 # Move up 10mm after Z homing/referencing
 z_hop_speed: 10
 
 
-[fan_generic parts_cooling]
-pin: PD13 #J50 on schematic
+[fan_generic Upper_Case_Fan]
+pin: PE5 #J51 on schematic
 max_power: 1.0
 shutdown_speed: 0
 #kick_start_time: 0.100
 
-[heater_fan my_nozzle_fan]
-pin: PE5 #J51 on schematic
-max_power: 1.0
+[heater_fan Nozzle_Fan]
+pin: PD12 #J52 on schematic
+;max_power: 1.0
 heater: extruder
 heater_temp: 50.0
 fan_speed: 1.0
-
-[heater_fan fan2]
-pin: PD12 #J52 on schematic
 
 #[heater_fan fan3]
 #pin: PD13
@@ -273,28 +266,20 @@ pin: PD12 #J52 on schematic
 
 
 
-################################### MACROS ###########
+################################### MACROS ###################################
 
-########################################
-# BEEP
-########################################
-[gcode_macro m300]
-description: Emits and audible beep.
-  Usage: M300 [P<duration>] [S<frequency>]
+[idle_timeout] 
+timeout: 36000
 gcode:
-  {% set km = printer["gcode_macro _km_globals"] %}
-  {% if "output_pin beeper" in printer %}
-    {% set P = (params.P|default(km.beep_duration)|int, 0)|max %}
-    {% set S = (params.S|default(km.beep_frequency)|int, 1)|max %}
-    SET_PIN PIN=beeper VALUE={
-        printer.configfile.settings["output_pin beeper"].scale * 0.5
-      } CYCLE_TIME={ 1.0 / S }
-    G4 P{P}
-    SET_PIN PIN=beeper VALUE=0
-  {% else %}
-    {action_respond_info(
-       "M300 is disabled. To enable create an [output_pin beeper] config.")}
-  {% endif %}
+    {% if printer.pause_resume.is_paused %}
+        M118 Bypassed Timeout
+        M117 Bypassed Timeout
+    {% else %}
+        M118 Timeout Reached
+        M117 Timeout Reached
+        TURN_OFF_HEATERS
+        M84
+    {% endif %}
 
 
 ########################################
@@ -307,11 +292,11 @@ gcode:
     {action_respond_info("This command cannot be used while printing")}
   {% elif printer.toolhead.homed_axes != "xyz" %}
     G28
+  {% endif %}
+    BED_MESH_CLEAR
     SAVE_GCODE_STATE NAME=G29
     M190 S60
     BED_MESH_CALIBRATE
-    SAFE_Z_HOME
-  {% endif %}
 
 
 [gcode_macro WIPE]
@@ -343,18 +328,16 @@ gcode:
   G1 X-17 Y35 F2000            ; fast wipe
   G1 X-15 Y25 F2000            ; fast wipe
   G1 X-17 Y35 F2000            ; fast wipe
-  G1 X-15 Y40 Z2 F2000         ; fast wipe
+  G1 X-15 Y40 Z2.0 F2000       ; fast wipe
   G1 X-17 Y35 F2000            ; fast wipe
   G1 X-15 Y40 F2000            ; fast wipe
   G1 X-17 Y35 F2000            ; fast wipe
   G1 E1 F75                    ; extrude filament back into the  nozzle
-  G1 X-15 Y30 Z1.5 F1000       ; slow wipe
+  G1 X-15 Y30 Z2.5 F1000       ; slow wipe
   G1 X-17 Y25 F1000            ; slow wipe
   G1 Z15                        ; raise extruder
   M109 S200                     ; heat to probe temp
   M204 S500                     ; set accel for probing
-
-
 
 
 ########################################
@@ -366,6 +349,7 @@ rename_existing: PAUSE_BASE
 gcode:
  PAUSE_BASE
   _TOOLHEAD_PARK_PAUSE_CANCEL
+
 
 [gcode_macro RESUME]
 description: Resume the actual running print
@@ -389,6 +373,7 @@ gcode:
   {% endif %}  
   RESUME_BASE {get_params}
 
+
 [gcode_macro CANCEL_PRINT]
 description: Cancel the actual running print
 rename_existing: CANCEL_PRINT_BASE
@@ -400,6 +385,7 @@ gcode:
   {% endif %}
   TURN_OFF_HEATERS
   CANCEL_PRINT_BASE
+
 
 [gcode_macro _TOOLHEAD_PARK_PAUSE_CANCEL]
 description: Helper: park toolhead used in PAUSE and CANCEL_PRINT
@@ -436,6 +422,7 @@ gcode:
     {action_respond_info("Printer not homed")}
   {% endif %}
 
+
 ######################################################################
 # FILAMENT CHANGE
 ######################################################################
@@ -463,6 +450,7 @@ gcode:
     G91
     G1 E-50 F1000
     RESTORE_GCODE_STATE NAME=M600_state
+
 
 [gcode_macro PRIME_NOZZLE]
 gcode:


### PR DESCRIPTION
updated pressure_advance per my machine.  Added include for Time Lapse, modified Prime Nozzle.  When the printer paused for filament change, it could Timeout and disable steppers.  When this happens, you have to restart your print.  I changed the default timeout to 10 hours.