### PR TITLE
Update printer_octopus.cfg

### DIFF
--- a/printer_octopus.cfg
+++ b/printer_octopus.cfg
@@ -228,7 +228,7 @@ kick_start_time: 0
 fan_speed: 0.9
 
 
-[fan_generic Extruder]
+[fan_generic extruder]
 pin: PD12 #J52 on schematic
 
 


### PR DESCRIPTION
apparently, you can't have a capital E for that word, it will give an alarm, fixed 🥇 