### PR TITLE
Update printer_octopus.cfg

### DIFF
--- a/printer_octopus.cfg
+++ b/printer_octopus.cfg
@@ -5,7 +5,7 @@ filename: ~/variables.cfg ; variable storage file
 # See docs/Config_Reference.md for a description of parameters.
 # MACROS AT THE BOTTOM OF THE CONFIG 
 # BED WILL LEVEL ITSELF EVERY 3 PRINTS, CHANGE NUMBER OF PRINTS IN START_PRINT MACRO, THANKS TO: https://www.reddit.com/r/klippers/comments/qdr0g9/my_gcode_macro_to_mesh_level_the_bed_every_10th/
-
+# WIPE NOZZLE USES 3 DIFFERENT PATHS BASED ON VARIABLE NUMBER IN variables.cfg 
 
 [mcu]
 serial: /dev/serial/by-id/usb-Klipper_stm32f446xx_370048001451313133353932-if00
@@ -248,36 +248,38 @@ pin: PD12 #J52 on schematic
 ########################################
 # START_PRINT MACRO
 ########################################
-
 [gcode_macro START_PRINT]
 gcode:
  M107 ; disable fans
  G90 ; absolute positioning
  M82 ; set extruder to absolute mode
  G92 E0 ; set extruder position to 0
-
  {% set BED_TEMP = params.BED_TEMP|default(60)|float %}
  {% set EXTRUDER_TEMP = params.EXTRUDER_TEMP|default(190)|float %}
+ M117 Heating Things Up
  M109 S{EXTRUDER_TEMP} ; start heating extruder
  M140 S{BED_TEMP} ; wait for bed temperature
  G1 F1000 E-3 ; retract filament 3 mm to prevent oozing
  WIPE ; clean nozzle
+ M117 ; Home Axis
  G28 ; home axis
  LEVEL_BED_ADVANCED MAX_AGE=3 ; level the bed after 3 prints
  M204 S500 ; set accel back to normal
  G1 X0 Y150 Z15 F5000 ; get out the way
  M400 ; clear buffer
+ M117 Clearing Buffer
  G4 S1 ; pause for buffer clear
- M117 Heating...
+ M117 Heating Things Up
  M109 S200 ; set extruder temp and wait
  M190 S60 ; wait for bed to reach printing temp
+ M117 Priming Nozzle
  PRIME_NOZZLE ; wipe the nozzle with the bottom left pad
  M117 AutoBots, Roll Out!
+
 
 ########################################
 # END_PRINT MACRO
 ########################################
-
 [gcode_macro END_PRINT]
 gcode:
  M400 ; wait for moves to finish
@@ -295,10 +297,10 @@ gcode:
  G90 ; absolute positioning
  M117 Print complete
 
+
 ########################################
 # Runs SAVE_CONFIG if the g-code variable was set in start gcode
 ########################################
-
 [gcode_macro SAVE_IF_SET]
 gcode:
   {% if printer["gcode_macro LEVEL_BED_ADVANCED"].save_at_end == 1 %}
@@ -306,6 +308,40 @@ gcode:
   SAVE_VARIABLE VARIABLE=level_age VALUE=1
   SAVE_CONFIG
   {% endif %}
+
+
+########################################
+# Wipe Nozzle Macros, Using Variables, Use Multiple Paths
+########################################
+[gcode_macro WIPE]
+description: Checks to see if alternative wipe line is needed
+variable_save_at_end: 0
+gcode:
+  ; load wipe_age from stored variables
+  {% set svv = printer.save_variables.variables %}
+  {% if "wipe_age" not in svv %} ; first run
+    SAVE_VARIABLE VARIABLE=wipe_age VALUE=1
+    {% set wipe_age = 1 %}
+  {% else %} ; load wipe_age and increment
+    {% set wipe_age = svv.wipe_age %}
+    SAVE_VARIABLE VARIABLE=wipe_age VALUE={wipe_age|int + 1}
+    {% endif %}
+  {action_respond_info("Wipe Age Is " + wipe_age|string) + "."}  
+  {% if wipe_age == 1 %}
+    {action_respond_info("Wipe Macro 1")} 
+    WIPE_1
+  {% endif %} 
+  {% if wipe_age == 2 %}
+    {action_respond_info("Wipe Macro 2")} 
+    WIPE_2
+  {% endif %} 
+  {% if wipe_age >= 3 %}
+    {action_respond_info("Reset Wipe Counter")} 
+    SAVE_VARIABLE VARIABLE=wipe_age VALUE=1 ; reset counter
+    {action_respond_info("Wipe Macro 3")} 
+    WIPE_3
+  {% endif %} 
+
 
 ########################################
 # M106, TURN FANS ON, MACRO
@@ -333,7 +369,6 @@ gcode:
     {% endif %}
 
 
-
 ########################################
 # M107, TURN FANS OFF, MACRO
 ########################################
@@ -344,7 +379,6 @@ gcode:
     {% else %}
       SET_FAN_SPEED FAN=extruder SPEED=0    
     {% endif %}
-
 
 
 ########################################
@@ -394,17 +428,64 @@ gcode:
     BED_MESH_PROFILE LOAD=default
   {% endif %} 
 
+
 ########################################
-# WIPE, BOTTOM LEFT PAD, PREP NOZZLE MACRO
+# WIPE #1, FRONT LEFT PAD, PREP NOZZLE MACRO
 ########################################
-[gcode_macro WIPE]
+[gcode_macro WIPE_1]
 description: Wipe the nozzle before printing
- M117 Wiping Nozzle
+ M117 Wiping Nozzle Macro #1
 gcode:
+  {% if 'xy' not in printer.toolhead.homed_axes %}
   G28
+  {% endif %}
   M109 S180                     ; soften filament for z homing
   G1 Z10                        ; raise nozzle
   G1 X-19 Y95 F2000            ; move to safe homing position
+  M104 S180                     ; wipe temp
+  G1 E-.5 F100                   ; suck up XXmm of filament
+  G1 X-17 Y90 F3000            ; move above wiper pad
+  G1 Z2.5                       ; push nozzle into wiper
+  G1 X-17 Y85 F1000            ; slow wipe
+  G1 X-17 Y80 F1000            ; slow wipe
+  G1 X-17 Y85 F1000            ; slow wipe
+  G1 X-19 Y80 F1000            ; slow wipe
+  G1 X-17 Y80 F1000            ; slow wipe
+  G1 X-19 Y70 F1000            ; slow wipe
+  G1 X-17 Y75 F2000            ; fast wipe
+  G1 X-19 Y70 F2000            ; fast wipe
+  G1 X-17 Y65 F2000            ; fast wipe
+  G1 X-19 Y60 F2000            ; fast wipe
+  G1 X-17 Y55 F2000            ; fast wipe
+  G1 X-19 Y50 F2000            ; fast wipe
+  G1 X-17 Y45 F2000            ; fast wipe
+  G1 X-19 Y40 F2000            ; fast wipe
+  G1 X-17 Y35 F2000            ; fast wipe
+  G1 X-19 Y25 F2000            ; fast wipe
+  G1 X-17 Y35 F2000            ; fast wipe
+  G1 X-19 Y40 Z2.0 F2000       ; fast wipe
+  G1 X-17 Y35 F2000            ; fast wipe
+  G1 X-19 Y40 F2000            ; fast wipe
+  G1 X-17 Y35 F2000            ; fast wipe
+  G1 E1 F75                    ; extrude filament back into the  nozzle
+  G1 X-19 Y30 Z2.5 F1000       ; slow wipe
+  G1 X-17 Y20 F1000            ; slow wipe
+  G1 Z15                        ; raise extruder
+  M204 S500                     ; set accel for probing
+  
+########################################
+# WIPE #2, FRONT LEFT PAD, PREP NOZZLE MACRO
+########################################
+[gcode_macro WIPE_2]
+description: Wipe the nozzle before printing
+ M117 Wiping Nozzle Macro #2
+gcode:
+  {% if 'xy' not in printer.toolhead.homed_axes %}
+  G28
+  {% endif %}
+  M109 S180                     ; soften filament for z homing
+  G1 Z10                        ; raise nozzle
+  G1 X-15 Y95 F2000            ; move to safe homing position
   M104 S180                     ; wipe temp
   G1 E-.5 F100                   ; suck up XXmm of filament
   G1 X-17 Y90 F3000            ; move above wiper pad
@@ -432,11 +513,53 @@ gcode:
   G1 X-17 Y35 F2000            ; fast wipe
   G1 E1 F75                    ; extrude filament back into the  nozzle
   G1 X-15 Y30 Z2.5 F1000       ; slow wipe
-  G1 X-17 Y25 F1000            ; slow wipe
+  G1 X-17 Y20 F1000            ; slow wipe
   G1 Z15                        ; raise extruder
-  M109 S200                     ; heat to probe temp
   M204 S500                     ; set accel for probing
-
+  
+########################################
+# WIPE FRONT LEFT PAD, PREP NOZZLE MACRO
+########################################
+[gcode_macro WIPE_3]
+description: Wipe the nozzle before printing
+ M117 Wiping Nozzle Macro #3
+gcode:
+  {% if 'xy' not in printer.toolhead.homed_axes %}
+  G28
+  {% endif %}
+  M109 S180                     ; soften filament for z homing
+  G1 Z10                        ; raise nozzle
+  G1 X-15 Y95 F2000            ; move to safe homing position
+  M104 S180                     ; wipe temp
+  G1 E-.5 F100                   ; suck up XXmm of filament
+  G1 X-13 Y90 F3000            ; move above wiper pad
+  G1 Z2.5                       ; push nozzle into wiper
+  G1 X-13 Y85 F1000            ; slow wipe
+  G1 X-13 Y80 F1000            ; slow wipe
+  G1 X-13 Y85 F1000            ; slow wipe
+  G1 X-15 Y80 F1000            ; slow wipe
+  G1 X-13 Y80 F1000            ; slow wipe
+  G1 X-15 Y70 F1000            ; slow wipe
+  G1 X-13 Y75 F2000            ; fast wipe
+  G1 X-15 Y70 F2000            ; fast wipe
+  G1 X-13 Y65 F2000            ; fast wipe
+  G1 X-15 Y60 F2000            ; fast wipe
+  G1 X-13 Y55 F2000            ; fast wipe
+  G1 X-15 Y50 F2000            ; fast wipe
+  G1 X-13 Y45 F2000            ; fast wipe
+  G1 X-15 Y40 F2000            ; fast wipe
+  G1 X-13 Y35 F2000            ; fast wipe
+  G1 X-15 Y25 F2000            ; fast wipe
+  G1 X-13 Y35 F2000            ; fast wipe
+  G1 X-15 Y40 Z2.0 F2000       ; fast wipe
+  G1 X-13 Y35 F2000            ; fast wipe
+  G1 X-15 Y40 F2000            ; fast wipe
+  G1 X-13 Y35 F2000            ; fast wipe
+  G1 E1 F75                    ; extrude filament back into the  nozzle
+  G1 X-15 Y30 Z2.5 F1000       ; slow wipe
+  G1 X-13 Y20 F1000            ; slow wipe
+  G1 Z15                        ; raise extruder
+  M204 S500                     ; set accel for probing
 
 
 ########################################
@@ -448,7 +571,6 @@ rename_existing: PAUSE_BASE
 gcode:
  PAUSE_BASE
   _TOOLHEAD_PARK_PAUSE_CANCEL
-
 
 
 ########################################
@@ -477,7 +599,6 @@ gcode:
   RESUME_BASE {get_params}
 
 
-
 ########################################
 # CANCEL PRINT MACRO
 ########################################
@@ -494,7 +615,6 @@ gcode:
   TURN_OFF_HEATERS
   CANCEL_PRINT_BASE
   M84
-
 
 
 ########################################
@@ -536,7 +656,6 @@ gcode:
   {% endif %}
 
 
-
 ########################################
 # FILAMENT CHANGE MACRO
 ########################################
@@ -555,7 +674,6 @@ gcode:
     G91
     G1 E-10 F1000
     RESTORE_GCODE_STATE NAME=M600_state
-
 
 
 ########################################
@@ -580,6 +698,7 @@ gcode:
     G1 Y-1 F1000
     RESTORE_GCODE_STATE NAME=PRIME_NOZZLE_STATE
 
+
 #*# <---------------------- SAVE_CONFIG ---------------------->
 #*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
 #*#
@@ -589,9 +708,9 @@ gcode:
 #*# [bed_mesh default]
 #*# version = 1
 #*# points =
-#*# 	  -0.080000, 0.058125, 0.166250, 0.290312, 0.420000
-#*# 	  0.115937, 0.102500, 0.061250, 0.022812, -0.020938
-#*# 	  0.433437, 0.256875, 0.016562, -0.209688, -0.429063
+#*# 	-0.172813, -0.030000, 0.097812, 0.220937, 0.349062
+#*# 	0.004375, 0.011562, -0.012500, -0.058750, -0.071875
+#*# 	0.318125, 0.135625, -0.070625, -0.278125, -0.493750
 #*# x_count = 5
 #*# y_count = 3
 #*# mesh_x_pps = 2


### PR DESCRIPTION
When the nozzle wipes, it nows counts to 3, increments of 1.  Each number uses a different wipe path, and it reset back to #1 automatically.